### PR TITLE
Fix AI suggestions for PPI needs and objectives

### DIFF
--- a/src/app/(app)/ppi/[studentId]/page.tsx
+++ b/src/app/(app)/ppi/[studentId]/page.tsx
@@ -38,6 +38,8 @@ const ppiFormSchema = administrativeSchema
   .merge(objectivesSchema)
   .merge(notesSchema);
 
+export type PpiFormValues = z.infer<typeof ppiFormSchema>;
+
 
 export default function PpiStudentPage({ params }: { params: { studentId: string } }) {
   const [student, setStudent] = useState<Student | null>(null);


### PR DESCRIPTION
## Summary
- sanitize and reuse full PPI form values when calling the AI suggestion flows so needs/objectives receive trimmed, deduplicated context and return cleaned results
- export the merged PPI form type for shared client components and update badge drag-and-drop wiring to keep drop handlers typed and active

## Testing
- npm run typecheck *(fails: existing issues in unrelated dashboard, document exporter, and repository modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d8eb7d54a08325932d149e44bc7ca5