### PR TITLE
Use Gemini 2.5 Flash model

### DIFF
--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -22,7 +22,7 @@ export const ai = genkit({
       apiKey: geminiApiKey,
     }),
   ],
-  model: googleAI.model('gemini-1.5-pro-latest', {
+  model: googleAI.model('gemini-2.5-flash', {
     apiKey: geminiApiKey,
   }),
 });


### PR DESCRIPTION
## Summary
- switch the Genkit Google AI model configuration to gemini-2.5-flash so the app targets the current Gemini release

## Testing
- npm run lint *(fails: command requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d9888c4f1c8325851905a4bce11442